### PR TITLE
Update twitter authentication/signup method

### DIFF
--- a/src/Social.php
+++ b/src/Social.php
@@ -132,7 +132,7 @@ class Social {
 				$access_token = $connection->oauth('oauth/access_token', ['oauth_verifier'=>$_GET['oauth_verifier']]);
 
 				$connection = new TwitterOAuth($twt_app_id, $twt_secret, $access_token['oauth_token'], $access_token['oauth_token_secret']);
-				$user = $connection->get('account/verify_credentials');
+				$user = $connection->get('account/verify_credentials', ['include_email' => 'true']);
 				if(!isset($user->errors)) {
 					$twtData = json_decode(json_encode($user),TRUE);
 					$name = explode(' ', $twtData['name']);


### PR DESCRIPTION
This update enables the API call to return the email as part of the response data by adding the parameter include_email to the API call that verifies the user credentials. Without this, the API is uncertain to return the email in the result.